### PR TITLE
twrpdtgen: Implement dynamic partition parser

### DIFF
--- a/twrpdtgen/templates/AndroidProducts.mk.jinja2
+++ b/twrpdtgen/templates/AndroidProducts.mk.jinja2
@@ -1,10 +1,10 @@
 {% include 'LICENSE' %}
 
 PRODUCT_MAKEFILES := \
-    $(LOCAL_DIR)/omni_{{ device_codename }}.mk
+    $(LOCAL_DIR)/{{ tw_vendor }}_{{ device_codename }}.mk
 
 COMMON_LUNCH_CHOICES := \
-    omni_{{ device_codename }}-user \
-    omni_{{ device_codename }}-userdebug \
-    omni_{{ device_codename }}-eng
+    {{ tw_vendor }}_{{ device_codename }}-user \
+    {{ tw_vendor }}_{{ device_codename }}-userdebug \
+    {{ tw_vendor }}_{{ device_codename }}-eng
 

--- a/twrpdtgen/templates/BoardConfig.mk.jinja2
+++ b/twrpdtgen/templates/BoardConfig.mk.jinja2
@@ -70,6 +70,14 @@ TARGET_USERIMAGES_USE_EXT4 := true
 TARGET_USERIMAGES_USE_F2FS := true
 TARGET_COPY_OUT_VENDOR := vendor
 
+{% if device_is_dynamic %}
+# Dynamic Partition
+BOARD_SUPER_PARTITION_GROUPS := {{ device_brand|lower }}_dynamic_partitions
+BOARD_{{ device_brand|upper }}_DYNAMIC_PARTITIONS_PARTITION_LIST := \
+    system \
+    vendor
+{% endif %}
+
 {% if device_is_ab %}
 # A/B
 AB_OTA_UPDATER := true

--- a/twrpdtgen/templates/device.mk.jinja2
+++ b/twrpdtgen/templates/device.mk.jinja2
@@ -31,3 +31,12 @@ PRODUCT_PACKAGES += \
     update_engine_sideload
 {% endif %}
 
+{% if device_is_dynamic %}
+# Dynamic Partition
+PRODUCT_USE_DYNAMIC_PARTITIONS := true
+
+# fastbootd
+PRODUCT_PACKAGES += \
+    android.hardware.fastboot@1.0-impl-mock \
+    fastbootd
+{% endif %}

--- a/twrpdtgen/templates/omni.mk.jinja2
+++ b/twrpdtgen/templates/omni.mk.jinja2
@@ -4,6 +4,8 @@
 {% if device_has_64bit_arch %}
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 {% endif %}
+
+$(call inherit-product-if-exists, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 $(call inherit-product-if-exists, $(SRC_TARGET_DIR)/product/embedded.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
@@ -11,13 +13,15 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
 # Inherit from {{ device_codename }} device
 $(call inherit-product, device/{{ device_manufacturer }}/{{ device_codename }}/device.mk)
 
-# Inherit some common Omni stuff.
-$(call inherit-product, vendor/omni/config/common.mk)
+# Inherit some common {{ tw_vendor }} stuff.
+$(call inherit-product, vendor/{{ tw_vendor }}/config/common.mk)
+{% if tw_vendor == "omni" %}
 $(call inherit-product, vendor/omni/config/gsm.mk)
+{% endif %}
 
 # Device identifier. This must come after all inclusions
 PRODUCT_DEVICE := {{ device_codename }}
-PRODUCT_NAME := omni_{{ device_codename }}
+PRODUCT_NAME := {{ tw_vendor }}_{{ device_codename }}
 PRODUCT_BRAND := {{ device_brand }}
 PRODUCT_MODEL := {{ device_model }}
 PRODUCT_MANUFACTURER := {{ device_manufacturer }}

--- a/twrpdtgen/utils/deviceinfo.py
+++ b/twrpdtgen/utils/deviceinfo.py
@@ -26,6 +26,7 @@ DEVICE_BRAND = get_product_props("brand")
 DEVICE_MODEL = get_product_props("model")
 DEVICE_ARCH = ["ro.product.cpu.abi", "ro.product.cpu.abilist"] + [f"ro.{partition}product.cpu.abi" for partition in PARTITIONS] + [f"ro.{partition}product.cpu.abilist" for partition in PARTITIONS]
 DEVICE_IS_AB = ["ro.build.ab_update"]
+DEVICE_IS_DYNAMIC = ["ro.boot.dynamic_partitions"]
 DEVICE_PLATFORM = ["ro.board.platform"]
 DEVICE_PIXEL_FORMAT = ["ro.minui.pixel_format"]
 
@@ -80,6 +81,7 @@ class DeviceInfo:
 		self.device_has_64bit_arch = self.arch in ("arm64", "x86_64")
 		self.platform = self.get_prop(DEVICE_PLATFORM, default="default")
 		self.device_is_ab = bool(strtobool(self.get_prop(DEVICE_IS_AB, default="false")))
+		self.device_is_dynamic = bool(strtobool(self.get_prop(DEVICE_IS_DYNAMIC, default="false")))
 		self.device_pixel_format = self.get_prop(DEVICE_PIXEL_FORMAT, raise_exception=False)
 		self.kernel_name = KERNEL_NAMES[self.arch]
 


### PR DESCRIPTION
overview on this merge:
1. twrp has moved from omni to their own aosp twrp base and unified A10(omni) and A11 twrp branch and A10 omni branch which was initially for dynamic partition devices is depricated. All dynamic partition devices needs to use aosp twrp base. so omni -> twrp is needed for dynamic partition devices
2. don't include add_lunch_combo for aosp twrp base as it is depricated on aosp

Signed-off by: iHemal <i.mominulislamhemal@gmail.com>